### PR TITLE
[refactor] CampDetail 이미지 지연 코드 리팩토링

### DIFF
--- a/src/pages/CampDetail/index.tsx
+++ b/src/pages/CampDetail/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useContext, useEffect, useRef, useState } from 'react';
+import { useContext, useEffect, useRef, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { observer } from 'mobx-react-lite';
 import { Padding, Skeleton } from 'components';
@@ -19,7 +19,7 @@ const CampDetail = () => {
   const campStore = useContext(CampsStore);
 
   const containerRef = useRef<HTMLDivElement>(null);
-  const imgRef = useRef<HTMLImageElement>(null);
+  const [loading, setLoading] = useState(true);
   const [height, setHeight] = useState<number>(0);
 
   const isMobile = useMediaQuery({
@@ -30,24 +30,6 @@ const CampDetail = () => {
     campStore.fetchCampById(String(campId));
   }, [campId, campStore]);
 
-  /**
-   * 모든 이미지가 로드 된 후, getHeight 함수를 호출한다.
-   */
-  const onloadImages = useCallback(() => {
-    if (imgRef.current) {
-      const imgs = imgRef.current.querySelectorAll('img');
-
-      for (let i = 0; i < imgs.length; i++) {
-        imgs[i].onload = () => {
-          if (i === imgs.length - 1) getHeight();
-        };
-      }
-    }
-  }, []);
-
-  /**
-   * 현재 container의 총 높이를 구한다
-   */
   const getHeight = () => {
     if (containerRef.current) {
       setHeight(containerRef.current.clientHeight);
@@ -55,40 +37,40 @@ const CampDetail = () => {
   };
 
   useEffect(() => {
-    campStore.targetCamp && onloadImages();
+    !loading && getHeight();
     window.addEventListener('resize', getHeight);
     return () => {
       window.removeEventListener('resize', getHeight);
     };
-  }, [campStore.targetCamp, onloadImages]);
+  }, [campStore.targetCamp, loading]);
 
   if (campStore.targetCamp) {
     return (
       <Container>
         <HeaderSection targetCamp={campStore.targetCamp} />
 
-        <Main ref={containerRef}>
+        <Wrapper ref={containerRef}>
           <InfoSection
             targetCamp={campStore.targetCamp}
             sidebarheight={height}
           />
-
-          {campStore.targetCamp && (
-            <ImageSection ref={imgRef} isMobile={isMobile}>
-              {campStore.targetCamp.images.map((img, index) => (
-                <article key={index}>
-                  <img src={img} alt="camp-detail-img" />
-                  <Padding height={'60px'} />
-                </article>
-              ))}
-            </ImageSection>
-          )}
-
+          <ImageSection isMobile={isMobile}>
+            {campStore.targetCamp.images.map((img, index) => (
+              <article key={index}>
+                <img
+                  onLoad={() => setLoading(false)}
+                  src={img}
+                  alt="camp-detail-img"
+                />
+                <Padding height={'60px'} />
+              </article>
+            ))}
+          </ImageSection>
           <ReviewSection
             reviews={campStore.targetCamp.reviews}
             theme={campStore.targetCamp.theme}
           />
-        </Main>
+        </Wrapper>
 
         <FaqSection faqs={campStore.targetCamp.faqs} />
       </Container>
@@ -111,7 +93,7 @@ const Container = styled.div`
   position: relative;
 `;
 
-const Main = styled.div``;
+const Wrapper = styled.div``;
 
 const ImageSection = styled.section<{ isMobile: boolean }>`
   ${maxWidth}


### PR DESCRIPTION
캠프 디테일 페이지에서, 이미지가 모두 로드된 후, isLoading이 false일때, Wrapper의 높이를 구한, 
그 다음 Sidebar 컴포넌트에 넘겨줌.
[refactor] CampDetail 이미지 지연 로직 리팩토링](https://github.com/rara-record/caffein/pull/83/commits/c01c29e4b39352da52f26ea9ee3eab4fe96c9ad3)

```diff
- onloadImages() 함수 삭제
+ <img onLoad={() => setLoading(false)} src={img} />
```

