### PR TITLE
[style] 코드의 가독성을 위한 수정, 함수 표현식에서 선언식으로 변경

### DIFF
--- a/src/pages/CampDetail/index.tsx
+++ b/src/pages/CampDetail/index.tsx
@@ -30,12 +30,6 @@ const CampDetail = () => {
     campStore.fetchCampById(String(campId));
   }, [campId, campStore]);
 
-  const getHeight = () => {
-    if (containerRef.current) {
-      setHeight(containerRef.current.clientHeight);
-    }
-  };
-
   useEffect(() => {
     !loading && getHeight();
     window.addEventListener('resize', getHeight);
@@ -43,6 +37,12 @@ const CampDetail = () => {
       window.removeEventListener('resize', getHeight);
     };
   }, [campStore.targetCamp, loading]);
+
+  function getHeight() {
+    if (containerRef.current) {
+      setHeight(containerRef.current.clientHeight);
+    }
+  }
 
   if (campStore.targetCamp) {
     return (


### PR DESCRIPTION
CampDetail 페이지에, useEffect가 두개로 분리되어있는데 코드의 가독성 향상을 위해 
getHeight() 함수를 표현식에서 선언식으로 변경함,
```diff
- const getHeight = () => { // .. dosomthing }
+ function getHeight() { // .. dosomthing }
```

[[style] 코드의 가독성을 위한 수정, 함수 표현식에서 선언식으로 변경](https://github.com/rara-record/caffein/commit/7d92668d6f794fbdb859c7e7ac77d797c3f353dc)