### PR TITLE
[fix] CampDetail 페이지 이미지 로드 로직 버그 수정

### DIFF
--- a/src/pages/CampDetail/index.tsx
+++ b/src/pages/CampDetail/index.tsx
@@ -31,6 +31,7 @@ const CampDetail = () => {
   }, [campId, campStore]);
 
   useEffect(() => {
+    setLoading(true);
     !loading && getHeight();
     window.addEventListener('resize', getHeight);
     return () => {
@@ -54,6 +55,7 @@ const CampDetail = () => {
             targetCamp={campStore.targetCamp}
             sidebarheight={height}
           />
+
           <ImageSection isMobile={isMobile}>
             {campStore.targetCamp.images.map((img, index) => (
               <article key={index}>
@@ -66,6 +68,7 @@ const CampDetail = () => {
               </article>
             ))}
           </ImageSection>
+
           <ReviewSection
             reviews={campStore.targetCamp.reviews}
             theme={campStore.targetCamp.theme}


### PR DESCRIPTION
캠프 디테일 페이지에서, getHeight 함수가 한번만 실행되는 버그 해결
setLoading state를 초기화 하는 로직 추가

```diff
+ useEffect(()) => { setLoading(true }, [])
```